### PR TITLE
Fix heading render in colab notebook.

### DIFF
--- a/colab.ipynb
+++ b/colab.ipynb
@@ -154,7 +154,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        ":### Example 1.3: Same as example 1.2, but now use `asm()` and `exe()` (option B)\n",
+        "### Example 1.3: Same as example 1.2, but now use `asm()` and `exe()` (option B)\n",
         "The assembler function `asm()` takes an instruction and converts it into machine code and stores it in memory at address s.pc. Once the entire assembly program is written into memory `mem[]`, the `exe()` function (aka ISS) can then exectute the machine code stored in memory."
       ],
       "metadata": {


### PR DESCRIPTION
Tiny formatting fix to render H3 correctly.

<img width="1075" alt="cummins-mbp 2022-12-30 at 11 55 32" src="https://user-images.githubusercontent.com/1636663/210107488-aa5e2d44-273a-4631-9b42-8526ef7b75bd.png">

should be:

<img width="1072" alt="cummins-mbp 2022-12-30 at 11 55 43" src="https://user-images.githubusercontent.com/1636663/210107501-133a3cab-e100-4d5e-8f0a-2016271b49bc.png">
