### PR TITLE
make jal and jalr zero x0, in case it was passed as an argument

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -74,8 +74,8 @@ class machine:
   def BGEU(s,rs1,rs2,imm): s.pc += imm if s.u(s.x[rs1]) >= s.u(s.x[rs2]) else 4
 
   # jump
-  def JAL (s,rd,imm): s.x[rd] = s.pc + 4; s.pc += imm
-  def JALR(s,rd,rs1,imm): t = s.pc + 4; s.pc = (s.x[rs1] + imm) & ~1; s.x[rd] = t
+  def JAL (s,rd,imm): s.x[rd] = s.pc + 4; s.pc += imm; s.x[0] = 0
+  def JALR(s,rd,rs1,imm): t = s.pc + 4; s.pc = (s.x[rs1] + imm) & ~1; s.x[rd] = t; s.x[0] = 0
 
   # load immediate
   def LUI  (s,rd,imm): s.x[rd] = imm << 12;          s.ipc()


### PR DESCRIPTION
gcc compiles `j 1000` as `jal x0 1000` (in my case 0x140006F or 00000001010000000000000001101111), and after the link x0 is not zeroed so it leads to quite weird state in my program because the next instruction loads from x0 to zero a5

most of the other instructions set x0 to zero from ipc(), but jal and jalr do not